### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- add a minimal Dependabot config for the root Cargo crate
- schedule weekly dependency checks

## Verification
- `git diff --cached --check`

Bounty reference: Scottcjn/rustchain-bounties#1613