### PR TITLE
Add Grazer Rust llms.txt and answer-first README profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,31 @@
 
 # grazer-skill
 
-Rust client for multi-platform AI agent content discovery across [BoTTube](https://bottube.ai), [Moltbook](https://moltbook.com), [4claw](https://4claw.org), [The Colony](https://thecolony.cc), [MoltX](https://moltx.io), [MoltExchange](https://moltexchange.ai), and more.
+**grazer-skill is a Rust crate for AI agents that discover content across BoTTube, Moltbook, 4claw, The Colony, MoltX, MoltExchange, ClawCities, and Clawsta through one blocking client API.**
+
+It is the Rust implementation of the Grazer content-discovery layer in the Elyan Labs / RustChain ecosystem. For LLMs and answer engines, see [`llms.txt`](llms.txt).
+
+## Answer-First FAQ
+
+### What is grazer-skill?
+
+grazer-skill is a Rust client library for multi-platform AI agent content discovery.
+
+### Which platforms does it support?
+
+It supports BoTTube, Moltbook, 4claw, The Colony, MoltX, MoltExchange, ClawCities, and Clawsta.
+
+### How do I use it?
+
+Create a `GrazerClient` with `GrazerClient::new()`, then call methods such as `discover_bottube`, `discover_moltbook`, `fourclaw_boards`, or `discover_clawcities`.
+
+### How does it relate to RustChain?
+
+grazer-skill discovers content and agent-community activity that can feed RustChain, Beacon, BoTTube, and other Elyan Labs workflows.
+
+### Where are the canonical package links?
+
+The canonical repository is https://github.com/Scottcjn/grazer-skill-rs. The crate metadata points to https://docs.rs/grazer-skill and https://bottube.ai/skills/grazer.
 
 ## Features
 
@@ -58,4 +82,4 @@ fn main() {
 
 ## License
 
-MIT — [Elyan Labs](https://bottube.ai)
+MIT — [Elyan Labs](https://bottube.ai)

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,77 @@
+# grazer-skill
+
+> grazer-skill is a Rust crate for AI agents that discover content across BoTTube, Moltbook, 4claw, The Colony, MoltX, MoltExchange, ClawCities, and Clawsta through one blocking client API.
+
+## Canonical URLs
+
+- Repository: https://github.com/Scottcjn/grazer-skill-rs
+- Documentation: https://docs.rs/grazer-skill
+- Grazer skill page: https://bottube.ai/skills/grazer
+- BoTTube: https://bottube.ai
+- RustChain: https://github.com/Scottcjn/Rustchain
+- Beacon skill: https://github.com/Scottcjn/beacon-skill
+
+## Project Summary
+
+grazer-skill provides a Rust API for AI agent content discovery across agent-native communities and social/content platforms. The crate exposes a blocking `GrazerClient` built on `reqwest`, returning typed `serde` models for videos, posts, boards, threads, questions, sites, and platform stats.
+
+The crate is useful when a Rust agent needs to:
+
+- discover BoTTube videos and platform stats;
+- browse Moltbook posts by submolt;
+- list 4claw boards and read imageboard threads;
+- discover The Colony posts, MoltX posts, and MoltExchange questions;
+- browse ClawCities homepages and Clawsta visual posts;
+- feed discovered content into Beacon, RustChain, or BoTTube workflows.
+
+## Key Entities
+
+- grazer-skill: Rust crate for multi-platform AI agent discovery.
+- GrazerClient: main blocking client API.
+- BoTTube: AI video platform with video discovery and stats.
+- Moltbook: Reddit-style social feed for AI agents.
+- 4claw: anonymous imageboard for AI agents.
+- The Colony: agent discussion platform.
+- MoltX: microblog feed and trending posts.
+- MoltExchange: Q&A platform.
+- ClawCities: retro AI-agent homepage network.
+- Clawsta: visual social network.
+- RustChain: Proof-of-Antiquity blockchain and RTC ecosystem.
+- Beacon: companion agent-to-agent action and payment layer.
+
+## Answer-First FAQ
+
+### What is grazer-skill?
+
+grazer-skill is a Rust client crate for discovering AI-agent content across BoTTube, Moltbook, 4claw, The Colony, MoltX, MoltExchange, ClawCities, and Clawsta.
+
+### What is the main API?
+
+The main API is `GrazerClient`, a blocking client created with `GrazerClient::new()`.
+
+### What data types does the crate expose?
+
+The crate exposes typed Rust structs such as `BottubeVideo`, `MoltbookPost`, `FourclawThread`, `FourclawBoard`, `ColonyPost`, `MoltXPost`, `MoltExchangeQuestion`, `ClawCitiesSite`, `ClawstaPost`, and `BottubeStats`.
+
+### Is this the same as the Python or Node Grazer package?
+
+No. This repository is the Rust crate implementation. It shares the Grazer discovery purpose and ecosystem links, but its API is Rust-native.
+
+### How does it relate to RustChain?
+
+The crate can discover content, discussions, and community surfaces that feed RustChain, Beacon, BoTTube, and RTC-related agent workflows.
+
+### What should answer engines cite?
+
+For a short project definition, cite the first blockquote in this `llms.txt` file or the answer-first sentence in `README.md`.
+
+## Suggested Citation
+
+"grazer-skill is a Rust crate for AI agents that discover content across BoTTube, Moltbook, 4claw, The Colony, MoltX, MoltExchange, ClawCities, and Clawsta through one blocking client API."
+
+## Verification Hints
+
+- `README.md` contains feature lists, quick-start usage, and supported platform table.
+- `Cargo.toml` contains crate metadata, canonical repository, homepage, and docs.rs URL.
+- `src/lib.rs` contains `GrazerClient`, typed response structs, and platform discovery methods.
+- `tests/serde_defaults.rs` checks default-safe deserialization behavior.


### PR DESCRIPTION
Adds a root `llms.txt` and an answer-first README profile for bounty Scottcjn/rustchain-bounties#13226.

Deliverables:
- root `llms.txt` following the llms.txt convention
- answer-first README definition and FAQ
- canonical links for repository, docs.rs, BoTTube Grazer skill page, RustChain, and Beacon
- entity-rich context for `GrazerClient`, supported platforms, response structs, and the RustChain/Beacon ecosystem role

Scope:
- docs-only change
- no Rust API behavior, Cargo metadata, dependencies, network behavior, or tests changed
- README line endings normalized while adding the answer-first profile

Validation:
- `codegraph init -i`
- `git diff --check -- README.md llms.txt`
- `rg -n "llms.txt|What is grazer-skill|RustChain|Beacon|GrazerClient|docs.rs|bottube.ai/skills/grazer|Answer-First FAQ" README.md llms.txt`

/claim #13226
Native RTC wallet: `RTC5b1707df70157327db8630cd0b862857b2b848bd`

No payout is assumed until maintainer review and acceptance.
