### PR TITLE
fix(http): surface non-2xx errors from discovery endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,25 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -268,6 +296,7 @@ dependencies = [
 name = "grazer-skill"
 version = "0.1.0"
 dependencies = [
+ "mockito",
  "reqwest",
  "serde",
  "serde_json",
@@ -339,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +387,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -612,6 +648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +692,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +727,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -804,6 +897,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1100,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1031,10 +1174,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -1196,6 +1357,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ reqwest = { version = "0.13", features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+
+[dev-dependencies]
+mockito = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! | Clawsta | Visual | `discover_clawsta` |
 
 use reqwest::blocking::Client;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Errors returned by the Grazer client.
 #[derive(Debug, thiserror::Error)]
@@ -230,6 +230,10 @@ impl GrazerClient {
         }
     }
 
+    fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
+        Ok(self.http.get(url).send()?.error_for_status()?.json()?)
+    }
+
     // ── BoTTube ─────────────────────────────────────────────────
 
     /// Discover videos on BoTTube.
@@ -248,7 +252,7 @@ impl GrazerClient {
         }
         url.push_str(&format!("limit={}", limit.unwrap_or(20)));
 
-        let resp: Vec<BottubeVideo> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<BottubeVideo> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -259,13 +263,13 @@ impl GrazerClient {
             query,
             limit.unwrap_or(20)
         );
-        let resp: Vec<BottubeVideo> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<BottubeVideo> = self.get_json(&url)?;
         Ok(resp)
     }
 
     /// Get BoTTube platform statistics.
     pub fn bottube_stats(&self) -> Result<BottubeStats> {
-        let resp: BottubeStats = self.http.get("https://bottube.ai/api/stats").send()?.json()?;
+        let resp: BottubeStats = self.get_json("https://bottube.ai/api/stats")?;
         Ok(resp)
     }
 
@@ -283,7 +287,7 @@ impl GrazerClient {
         }
         url.push_str(&format!("limit={}", limit.unwrap_or(20)));
 
-        let resp: Vec<MoltbookPost> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<MoltbookPost> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -291,11 +295,7 @@ impl GrazerClient {
 
     /// List all 4claw boards.
     pub fn fourclaw_boards(&self) -> Result<Vec<FourclawBoard>> {
-        let resp: Vec<FourclawBoard> = self
-            .http
-            .get("https://www.4claw.org/api/v1/boards")
-            .send()?
-            .json()?;
+        let resp: Vec<FourclawBoard> = self.get_json("https://www.4claw.org/api/v1/boards")?;
         Ok(resp)
     }
 
@@ -310,14 +310,14 @@ impl GrazerClient {
             "https://www.4claw.org/api/v1/boards/{board}/threads?limit={}",
             limit.unwrap_or(20).min(20)
         );
-        let resp: Vec<FourclawThread> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<FourclawThread> = self.get_json(&url)?;
         Ok(resp)
     }
 
     /// Get a specific 4claw thread with replies.
     pub fn fourclaw_thread(&self, thread_id: &str) -> Result<serde_json::Value> {
         let url = format!("https://www.4claw.org/api/v1/threads/{thread_id}");
-        let resp: serde_json::Value = self.http.get(&url).send()?.json()?;
+        let resp: serde_json::Value = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -335,7 +335,7 @@ impl GrazerClient {
         }
         url.push_str(&format!("limit={}", limit.unwrap_or(20)));
 
-        let resp: Vec<ColonyPost> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<ColonyPost> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -347,7 +347,7 @@ impl GrazerClient {
             "https://moltx.io/v1/posts?limit={}",
             limit.unwrap_or(20)
         );
-        let resp: Vec<MoltXPost> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<MoltXPost> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -357,7 +357,7 @@ impl GrazerClient {
             "https://moltx.io/v1/posts/trending?limit={}",
             limit.unwrap_or(20)
         );
-        let resp: Vec<MoltXPost> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<MoltXPost> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -372,7 +372,7 @@ impl GrazerClient {
             "https://moltexchange.ai/v1/questions?limit={}",
             limit.unwrap_or(20)
         );
-        let resp: Vec<MoltExchangeQuestion> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<MoltExchangeQuestion> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -384,7 +384,7 @@ impl GrazerClient {
             "https://clawcities.com/api/v1/sites?limit={}",
             limit.unwrap_or(20)
         );
-        let resp: Vec<ClawCitiesSite> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<ClawCitiesSite> = self.get_json(&url)?;
         Ok(resp)
     }
 
@@ -396,7 +396,7 @@ impl GrazerClient {
             "https://clawsta.io/v1/posts?limit={}",
             limit.unwrap_or(20)
         );
-        let resp: Vec<ClawstaPost> = self.http.get(&url).send()?.json()?;
+        let resp: Vec<ClawstaPost> = self.get_json(&url)?;
         Ok(resp)
     }
 }
@@ -419,5 +419,72 @@ mod tests {
     #[test]
     fn test_default_impl() {
         let _client = GrazerClient::default();
+    }
+
+    fn assert_http_status<T: std::fmt::Debug>(result: Result<T>, expected: reqwest::StatusCode) {
+        match result {
+            Err(GrazerError::Http(error)) => {
+                assert_eq!(
+                    error.status(),
+                    Some(expected),
+                    "unexpected error: {error:?}"
+                );
+            }
+            other => panic!("expected HTTP {expected} error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_json_preserves_404_status_before_decoding() {
+        let mut server = mockito::Server::new();
+        let request = server
+            .mock("GET", "/missing")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"not found"}"#)
+            .create();
+        let client = GrazerClient::new();
+
+        let result: Result<serde_json::Value> =
+            client.get_json(&format!("{}/missing", server.url()));
+
+        request.assert();
+        assert_http_status(result, reqwest::StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn get_json_preserves_500_status_before_malformed_json() {
+        let mut server = mockito::Server::new();
+        let request = server
+            .mock("GET", "/broken")
+            .with_status(500)
+            .with_body("not json")
+            .create();
+        let client = GrazerClient::new();
+
+        let result: Result<serde_json::Value> =
+            client.get_json(&format!("{}/broken", server.url()));
+
+        request.assert();
+        assert_http_status(result, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn get_json_decodes_successful_json() {
+        let mut server = mockito::Server::new();
+        let request = server
+            .mock("GET", "/ok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true}"#)
+            .create();
+        let client = GrazerClient::new();
+
+        let value: serde_json::Value = client
+            .get_json(&format!("{}/ok", server.url()))
+            .expect("successful JSON response should decode");
+
+        request.assert();
+        assert_eq!(value, serde_json::json!({"ok": true}));
     }
 }


### PR DESCRIPTION
## Summary

- Add a private generic `get_json` helper that checks HTTP status before decoding JSON.
- Route all 13 public read methods through the shared status-checking pipeline without changing their public API or endpoint URLs.
- Add mockito regression coverage for 404, 500 with malformed JSON, and successful 200 JSON responses.

Previously, discovery methods called `Response::json()` immediately, so non-2xx responses could surface as JSON decode errors instead of preserving the HTTP status. The new helper calls `error_for_status()` before deserialization.

## Verification

- `cargo test --locked`: 11 passed (5 unit, 5 integration, 1 doc test)
- `cargo clippy --locked --all-targets -- -D warnings`: passed
- `git diff --check`: passed

`cargo fmt -- --check` reports only the three pre-existing formatting differences in the upstream source.