### PR TITLE
fix(http): percent-encode discovery query params without bypassing error_for_status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ai-agent", "bottube", "social-media", "content-discovery", "grazer"
 categories = ["api-bindings", "web-programming"]
 
 [dependencies]
-reqwest = { version = "0.13", features = ["json", "blocking"] }
+reqwest = { version = "0.13", features = ["json", "blocking", "query"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,21 @@ impl GrazerClient {
         Ok(self.http.get(url).send()?.error_for_status()?.json()?)
     }
 
+    /// Same contract as `get_json`, but lets reqwest build the query string
+    /// so every value gets percent-encoded. Hand-built `format!("...{v}...")`
+    /// query strings break on any value containing a reserved character
+    /// (`&`, `#`, `+`, `=`, space): the embedded delimiter gets read as a
+    /// parameter separator by the server instead of as data.
+    fn get_json_query<T: DeserializeOwned>(&self, url: &str, params: &[(&str, String)]) -> Result<T> {
+        Ok(self
+            .http
+            .get(url)
+            .query(params)
+            .send()?
+            .error_for_status()?
+            .json()?)
+    }
+
     // ── BoTTube ─────────────────────────────────────────────────
 
     /// Discover videos on BoTTube.
@@ -243,27 +258,28 @@ impl GrazerClient {
         agent: Option<&str>,
         limit: Option<u32>,
     ) -> Result<Vec<BottubeVideo>> {
-        let mut url = "https://bottube.ai/api/videos?".to_string();
+        let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(cat) = category {
-            url.push_str(&format!("category={cat}&"));
+            params.push(("category", cat.to_string()));
         }
         if let Some(ag) = agent {
-            url.push_str(&format!("agent={ag}&"));
+            params.push(("agent", ag.to_string()));
         }
-        url.push_str(&format!("limit={}", limit.unwrap_or(20)));
+        params.push(("limit", limit.unwrap_or(20).to_string()));
 
-        let resp: Vec<BottubeVideo> = self.get_json(&url)?;
+        let resp: Vec<BottubeVideo> =
+            self.get_json_query("https://bottube.ai/api/videos", &params)?;
         Ok(resp)
     }
 
     /// Search BoTTube videos by query.
     pub fn search_bottube(&self, query: &str, limit: Option<u32>) -> Result<Vec<BottubeVideo>> {
-        let url = format!(
-            "https://bottube.ai/api/videos/search?q={}&limit={}",
-            query,
-            limit.unwrap_or(20)
-        );
-        let resp: Vec<BottubeVideo> = self.get_json(&url)?;
+        let params = [
+            ("q", query.to_string()),
+            ("limit", limit.unwrap_or(20).to_string()),
+        ];
+        let resp: Vec<BottubeVideo> =
+            self.get_json_query("https://bottube.ai/api/videos/search", &params)?;
         Ok(resp)
     }
 
@@ -281,13 +297,14 @@ impl GrazerClient {
         submolt: Option<&str>,
         limit: Option<u32>,
     ) -> Result<Vec<MoltbookPost>> {
-        let mut url = "https://www.moltbook.com/api/v1/posts?".to_string();
+        let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = submolt {
-            url.push_str(&format!("submolt={s}&"));
+            params.push(("submolt", s.to_string()));
         }
-        url.push_str(&format!("limit={}", limit.unwrap_or(20)));
+        params.push(("limit", limit.unwrap_or(20).to_string()));
 
-        let resp: Vec<MoltbookPost> = self.get_json(&url)?;
+        let resp: Vec<MoltbookPost> =
+            self.get_json_query("https://www.moltbook.com/api/v1/posts", &params)?;
         Ok(resp)
     }
 
@@ -329,13 +346,14 @@ impl GrazerClient {
         colony: Option<&str>,
         limit: Option<u32>,
     ) -> Result<Vec<ColonyPost>> {
-        let mut url = "https://thecolony.cc/api/v1/posts?".to_string();
+        let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(c) = colony {
-            url.push_str(&format!("colony={c}&"));
+            params.push(("colony", c.to_string()));
         }
-        url.push_str(&format!("limit={}", limit.unwrap_or(20)));
+        params.push(("limit", limit.unwrap_or(20).to_string()));
 
-        let resp: Vec<ColonyPost> = self.get_json(&url)?;
+        let resp: Vec<ColonyPost> =
+            self.get_json_query("https://thecolony.cc/api/v1/posts", &params)?;
         Ok(resp)
     }
 
@@ -486,5 +504,57 @@ mod tests {
 
         request.assert();
         assert_eq!(value, serde_json::json!({"ok": true}));
+    }
+
+    #[test]
+    fn get_json_query_percent_encodes_reserved_characters() {
+        // A value containing '&' built into a hand-written format!() query
+        // string ("q={query}&limit=20") would be read by the server as a
+        // second parameter, truncating the real query. reqwest's .query()
+        // must percent-encode it so the server sees the literal value.
+        let mut server = mockito::Server::new();
+        let request = server
+            .mock("GET", "/search")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "q".into(),
+                "rust & go".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true}"#)
+            .create();
+        let client = GrazerClient::new();
+
+        let params = [("q", "rust & go".to_string())];
+        let value: serde_json::Value = client
+            .get_json_query(&format!("{}/search", server.url()), &params)
+            .expect("percent-encoded query should reach the mock");
+
+        request.assert();
+        assert_eq!(value, serde_json::json!({"ok": true}));
+    }
+
+    #[test]
+    fn get_json_query_preserves_error_status_before_decoding() {
+        // Same error_for_status()-before-json() contract as get_json above,
+        // just through the query-building path -- the percent-encoding fix
+        // must not reintroduce the "decode the error body as the success
+        // type" bug that get_json (#17) already closed.
+        let mut server = mockito::Server::new();
+        let request = server
+            .mock("GET", "/search")
+            .match_query(mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"not found"}"#)
+            .create();
+        let client = GrazerClient::new();
+
+        let params = [("q", "anything".to_string())];
+        let result: Result<serde_json::Value> =
+            client.get_json_query(&format!("{}/search", server.url()), &params);
+
+        request.assert();
+        assert_http_status(result, reqwest::StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
Supersedes #16, closed in favor of this one -- rebased clean on top of #17 (already-merged `get_json()` + `error_for_status()` helper) instead of carrying the pre-#17 fork.

Reviewer feedback on #16 (thank you): the percent-encoding fix built the query with reqwest's `.query()` but called `.send()?.json()?` directly, bypassing `get_json()`'s `error_for_status()` -- so on a non-2xx response the error body got decoded as the success type instead of raising.

**Fix:** added `get_json_query()`, a sibling to `get_json()` that takes `(url, params)` and chains `.query(params).send()?.error_for_status()?.json()?` together, then routed `discover_bottube` / `search_bottube` / `discover_moltbook` / `discover_colony` through it instead of the hand-built `format!("...{v}...")` query strings that don't percent-encode reserved characters (`&`, `#`, `+`, `=`, space).

Had to add the `query` cargo feature to `reqwest` -- `RequestBuilder::query` is feature-gated and wasn't previously enabled.

**Tests:** two new regression tests via mockito -- one asserts a value containing `&` reaches the mock server as the correct percent-decoded literal (`match_query` `UrlEncoded`), the other asserts a 404 hit through the query path still surfaces as an HTTP error instead of being decoded as the success type. Mutation-checked: breaking either the query-building or the `error_for_status()` call fails exactly its matching test. Full suite green: 13 tests + 1 doctest, `cargo clippy --all-targets` clean.

RTC address for auto-pay: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`